### PR TITLE
Update runner images

### DIFF
--- a/utilities/actrc.symlink
+++ b/utilities/actrc.symlink
@@ -1,4 +1,4 @@
 # set to use slim images by default for some of the common runner types in github workflows
--P ubuntu-latest=node:12-buster-slim
--P ubuntu-20.04=node:12-buster-slim
--P ubuntu-18.04=node:12-buster-slim
+-P ubuntu-latest=hessingd/buster-slim-with-utilities:1.1
+-P ubuntu-20.04=hessingd/buster-slim-with-utilities:1.1
+-P ubuntu-18.04=hessingd/buster-slim-with-utilities:1.1


### PR DESCRIPTION
Update the `.actrc` file to pass the `hessingd/buster-slim-with-utilities:1.1` as a default stand-in for Github runners using `ubuntu-latest`, `ubuntu-20.04`, and `ubuntu-18.04`.